### PR TITLE
Fixes issue with IE8 slow script warning.

### DIFF
--- a/jqBootstrapValidation.js
+++ b/jqBootstrapValidation.js
@@ -30,14 +30,13 @@
 
         var $siblingElements = this;
 
-        $.unique(
-          $siblingElements.map(
-            function () {
-              var $this = $(this);
-              return $this.parents("form")[0];
-            }
-          )
-        ).bind("submit", function (e) {
+        var uniqueForms = $.unique(
+          $siblingElements.map( function () {
+            return $(this).parents("form")[0];
+          }).toArray()
+        );
+
+        $(uniqueForms).bind("submit", function (e) {
           var $form = $(this);
           var warningsFound = 0;
           var $inputs = $form.find("input,textarea,select").not("[type=submit],[type=image]");


### PR DESCRIPTION
http://jsfiddle.net/QAWyd/2/

jQuery.unique takes a regular array, not a jQuery object (http://api.jquery.com/jQuery.unique/). In IE8 calling unique on the wrong set of elements will end up with an infinite loop.

This is a better fix for issue #15:
https://github.com/ReactiveRaven/jqBootstrapValidation/pull/15
