### PR TITLE
add message container if not exists (help-block)

### DIFF
--- a/jqBootstrapValidation.js
+++ b/jqBootstrapValidation.js
@@ -80,6 +80,12 @@
             $form = $this.parents("form").first(),
             validatorNames = [];
 
+          // create message container if not exists
+          if (!$helpBlock.length) {
+              $helpBlock = $('<div class="help-block" />');
+              $controlGroup.find('.controls').append($helpBlock);
+          }
+
           // =============================================================
           //                                     SNIFF HTML FOR VALIDATORS
           // =============================================================


### PR DESCRIPTION
Sometimes you don't have a `help-block`. You can add a empty element, but this is not clean so simple add it when it not exist.
