### PR TITLE
Add a prependExistingHelpBlock option

### DIFF
--- a/jqBootstrapValidation.js
+++ b/jqBootstrapValidation.js
@@ -18,6 +18,7 @@
 	
 	var defaults = {
 		options: {
+			prependExistingHelpBlock: false,
 			sniffHtml: true, // sniff for 'required', 'maxlength', etc
 			preventSubmit: true, // stop the form submit event from firing if validation fails
 			submitError: false,
@@ -474,7 +475,8 @@
 
               if (errorsFound.length) {
                 $controlGroup.removeClass("success error").addClass("warning");
-                $helpBlock.html("<ul role=\"alert\"><li>" + errorsFound.join("</li><li>") + "</li></ul>");
+                $helpBlock.html("<ul role=\"alert\"><li>" + errorsFound.join("</li><li>") + "</li></ul>" +
+                                ( settings.options.prependExistingHelpBlock ? $helpBlock.data("original-contents") : "" ));
               } else {
                 $controlGroup.removeClass("warning error success");
                 if (value.length > 0) {


### PR DESCRIPTION
If an existing help block is found, prepend errors into the block instead of overwriting the content in the block.

For example if the help block already contained some text, it would just insert the list of errors before that text.

This is exposed as an option (`prependExistingHelpBlock`) that is off by default in order not to break functionality on users who have been using previous versions.
