### PR TITLE
 Single error message without list 

### DIFF
--- a/jqBootstrapValidation.js
+++ b/jqBootstrapValidation.js
@@ -474,9 +474,13 @@
               errorsFound = $.unique(errorsFound);
 
               if (errorsFound.length) {
-                $controlGroup.removeClass("success error").addClass("warning");
-                $helpBlock.html("<ul role=\"alert\"><li>" + errorsFound.join("</li><li>") + "</li></ul>" +
-                                ( settings.options.prependExistingHelpBlock ? $helpBlock.data("original-contents") : "" ));
+                if (errorsFound.length == 1) {
+                  $helpBlock.html(errorsFound[0] + 
+                    ( settings.options.prependExistingHelpBlock ? $helpBlock.data("original-contents") : "" ));
+                } else {
+                  $helpBlock.html("<ul role=\"alert\"><li>" + errorsFound.join("</li><li>") + "</li></ul>" +
+                    ( settings.options.prependExistingHelpBlock ? $helpBlock.data("original-contents") : "" ));
+                }
               } else {
                 $controlGroup.removeClass("warning error success");
                 if (value.length > 0) {


### PR DESCRIPTION
This PR changes the behaviour of the error message when only one error was raised for a given field. Previously, a list (&lt;ul&gt;) would be generated with a single item (&lt;li&gt;) in it. 

I found this to be semantically strange and also visually ugly, hence this PR. Of course this is up to the owner's decision. 
