### PR TITLE
Added support for help-inline

### DIFF
--- a/jqBootstrapValidation.js
+++ b/jqBootstrapValidation.js
@@ -85,10 +85,16 @@
             $helpBlock = $controlGroup.find(".help-block").first(),
             $form = $this.parents("form").first(),
             validatorNames = [];
+		
+		  if($helpBlock.length == 0)$helpBlock = $controlGroup.find(".help-inline").first();
 
           // create message container if not exists
-          if (!$helpBlock.length && settings.options.autoAdd && settings.options.autoAdd.helpBlocks) {
-              $helpBlock = $('<div class="help-block" />');
+          if (!$helpBlock.length && settings.options.autoAdd && (settings.options.autoAdd.helpBlocks || settings.options.autoAdd.helpInline)) {
+              if(settings.options.autoAdd.helpInline){
+				$helpBlock = $('<span class="help-inline" />');
+			  }else{
+				$helpBlock = $('<div class="help-block" />');
+			  }
               $controlGroup.find('.controls').append($helpBlock);
 							createdElements.push($helpBlock[0]);
           }


### PR DESCRIPTION
Added optional suport for using help-inline spans instead of help-block.

If no help-block is found in the control group it will look for help-inline instead. You can also auto insert them by setting the autoAdd.helpInline option to true.

element.jqBootstrapValidation({autoAdd: {helpBlocks: false, helpInline: true}});
