### PR TITLE
Swapped use of .indexOf on arrays to $.inArray()

### DIFF
--- a/src/jqBootstrapValidation.js
+++ b/src/jqBootstrapValidation.js
@@ -565,10 +565,10 @@
             $this.attr("aria-invalid", $this.data("original-aria-invalid"));
             // reset role
             $helpBlock.attr("role", $this.data("original-role"));
-						// remove all elements we created
-                        if ($.inArray($helpBlock[0], createdElements) > -1) {
-							$helpBlock.remove();
-						}
+            // remove all elements we created
+            if ($.inArray($helpBlock[0], createdElements) > -1) {
+                $helpBlock.remove();
+            }
 
           }
         );


### PR DESCRIPTION
`.indexOf` isn't supported on arrays for Internet Explorer 8 or less. I swapped it out for jQuery's own `$.inArray()` which returns the same result as `.indexOf()` would, in a browser which supports it.

Not possible to write a test for this.
