### PR TITLE
Move settings.options.bindEvents defaults from condtional to defaults.options.bindEvents

### DIFF
--- a/src/jqBootstrapValidation.js
+++ b/src/jqBootstrapValidation.js
@@ -11,7 +11,15 @@
             submitSuccess: false, // function called just before a successful submit event is sent to the server
             semanticallyStrict: false, // set to true to tidy up generated HTML output
             removeSuccess : true,
-            bindEvents: [],
+            bindEvents: [
+                "keyup",
+                "focus",
+                "blur",
+                "click",
+                "keydown",
+                "keypress",
+                "change"
+            ],
             autoAdd: {
                 helpBlocks: true
             },
@@ -509,19 +517,7 @@
                         }
                     );
                     $this.bind(
-                        (
-                            settings.options.bindEvents.length > 0 ?
-                                settings.options.bindEvents :
-                                [
-                                    "keyup",
-                                    "focus",
-                                    "blur",
-                                    "click",
-                                    "keydown",
-                                    "keypress",
-                                    "change"
-                                ]
-                            ).concat(["revalidate"]).join(".validation ") + ".validation",
+                        (settings.options.bindEvents).concat(["revalidate"]).join(".validation ") + ".validation",
                         function (e, params) {
 
                             var value = getValue($this);


### PR DESCRIPTION
Why would it not be like this.

Doing this because, to me, it looks cleaner.

It appears that deep in the code there is a default option for settings.options.bindEvents.
But it isn't clear that it is there because defaults.options.bindEvents is an empty array.
Why would there be the conditional to provide the default? I can see the only difference is handling the case of  if settings.options.bindEvents is [].

Someone can explain to me why it was the way it was.
