### PR TITLE
changed regex to accept Top-level domain with length 63

### DIFF
--- a/src/jqBootstrapValidation.js
+++ b/src/jqBootstrapValidation.js
@@ -819,7 +819,7 @@
                 name: "email",
                 init: function ($this, name) {
                     var result = {};
-                    result.regex = regexFromString('[a-zA-Z0-9.!#$%&\u2019*+/=?^_`{|}~-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,4}');
+                    result.regex = regexFromString('[a-zA-Z0-9.!#$%&\u2019*+/=?^_`{|}~-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,63}');
 
                     var message = "Not a valid email address";
                     if ($this.data("validation" + name + "Message")) {

--- a/test/jqBootstrapValidation_test.js
+++ b/test/jqBootstrapValidation_test.js
@@ -178,7 +178,8 @@
         '!def!xyz%abc@example.com',
         '_somename@example.com',
         'test@example.com',
-        '\u2019test\u2019@example.com'
+        '\u2019test\u2019@example.com',
+        'someone@tld63char.abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabc'
       ];
       test('accepts valid', validEmails.length * numInJQBVTest, function() {
           $(validEmails).each(function (i, el) {


### PR DESCRIPTION
Hi,

According to IETF, A TLD label MUST be at least two characters long and MAY be as long as 63 characters.
[https://tools.ietf.org/id/draft-liman-tld-names-00.html#:~:text=A%20TLD%20label%20MUST%20be,or%20trailing%20periods%20(.).](https://tools.ietf.org/id/draft-liman-tld-names-00.html#:~:text=A%20TLD%20label%20MUST%20be,or%20trailing%20periods%20(.).)

changed max length value of the regular expression.